### PR TITLE
update routes for nginx

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,8 +37,8 @@ app.use(
 );
 app.use(limiter);
 
-app.use("/users", usersRouter);
-app.use("/send", sendRouter);
+app.use("/api/users", usersRouter);
+app.use("/api/send", sendRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {


### PR DESCRIPTION
Updating the nginx config to prefix the routes with `/api/` broke the server because nginx passes on the prefix along with the rest of the path (who knew). This should (🤞 ) fix the issue